### PR TITLE
Update imap.cfc

### DIFF
--- a/imap/imap.cfc
+++ b/imap/imap.cfc
@@ -71,17 +71,32 @@ component output="false" accessors="true" singleton {
 
 	}
 
-	public function markRead( required connection, string folder ){
+	public function markRead( required connection, string folder, string messageNumber = "", string uid = "" ){
 
 		var flag = CreateObject("Java", "javax.mail.Flags$Flag");
 		var objFolder = getFolder( arguments.connection, arguments.folder );
-		objFolder.open( objFolder.READ_WRITE );
-		var messages = objFolder.getMessages();
 
-		loop from="1" to="#ArrayLen( messages )#" step="1" index="index"{
-			messages[index].setFlag(flag.SEEN, true);
+		if (arguments.uid neq "" or arguments.messageNumber neq "") {
+			objFolder.open( objFolder.READ_WRITE );
+			var messages = objFolder.getMessages();
+			var index = 0;
+
+			loop from="1" to="#ArrayLen( messages )#" step="1" index="index"{
+				if (arguments.uid neq "") {
+					if (listfind(arguments.uid, objFolder.getUID(messages[index]))) {
+						messages[index].setFlag(flag.SEEN, true);
+					}
+				}
+				else if (arguments.messageNumber neq "") {
+					if (listfind(arguments.messageNumber, objFolder.getMessageNumber(messages[index]))) {
+						messages[index].setFlag(flag.SEEN, true);
+					}
+				}
+			}
+			objFolder.close(true);
 		}
-		objFolder.close(true);
+		else
+			throw "uid and messageNumber are empty."
 
 		return messages;
 

--- a/imap/imap.cfc
+++ b/imap/imap.cfc
@@ -71,27 +71,24 @@ component output="false" accessors="true" singleton {
 
 	}
 
-	public function markRead( required connection, string folder, string messageNumber = "", string uid = "" ){
+	public function markRead( string folder, string messageNumber = "", string uid = "" ){
 
 		var flag = CreateObject("Java", "javax.mail.Flags$Flag");
-		var objFolder = getFolder( arguments.connection, arguments.folder );
+		var objFolder = getFolder( arguments.folder );
 
 		if (arguments.uid neq "" or arguments.messageNumber neq "") {
 			objFolder.open( objFolder.READ_WRITE );
-			var messages = objFolder.getMessages();
 			var index = 0;
 
+			if (structKeyExists(arguments, "uid") and listlen(arguments.uid))
+				var messages = objFolder.getMessagesByUID( JavaCast( "int[]", ListToArray(arguments.uid)) );
+			else if (listlen(arguments.messageNumber))
+				var messages = objFolder.getMessages( JavaCast( "int[]", ListToArray(arguments.messageNumber)) );
+			else
+				throw "uid and messageNumber are empty."
+
 			loop from="1" to="#ArrayLen( messages )#" step="1" index="index"{
-				if (arguments.uid neq "") {
-					if (listfind(arguments.uid, objFolder.getUID(messages[index]))) {
-						messages[index].setFlag(flag.SEEN, true);
-					}
-				}
-				else if (arguments.messageNumber neq "") {
-					if (listfind(arguments.messageNumber, objFolder.getMessageNumber(messages[index]))) {
-						messages[index].setFlag(flag.SEEN, true);
-					}
-				}
+				messages[index].setFlag(flag.SEEN, true);
 			}
 			objFolder.close(true);
 		}
@@ -110,22 +107,20 @@ component output="false" accessors="true" singleton {
 
 		if (arguments.uid neq "" or arguments.messageNumber neq "") {
 			objFolder.open( objFolder.READ_WRITE );
-			var messages = objFolder.getMessages();
+			var index = 0;
+
+			if (structKeyExists(arguments, "uid") and listlen(arguments.uid))
+				var messages = objFolder.getMessagesByUID( JavaCast( "int[]", ListToArray(arguments.uid)) );
+			else if (listlen(arguments.messageNumber))
+				var messages = objFolder.getMessages( JavaCast( "int[]", ListToArray(arguments.messageNumber)) );
+			else
+				throw "uid and messageNumber are empty."
 
 			loop from="1" to="#ArrayLen( messages )#" step="1" index="index"{
-				if (arguments.uid neq "") {
-					if (listfind(arguments.uid, objFolder.getUID(messages[index]))) {
-						messages[index].setFlag(flag.DELETED, true);
-						deleted++;
-					}
-				}
-				else if (arguments.messageNumber neq "") {
-					if (listfind(arguments.messageNumber, objFolder.getMessageNumber(messages[index]))) {
-						messages[index].setFlag(flag.DELETED, true);
-						deleted++;
-					}
-				}
+				messages[index].setFlag(flag.DELETED, true);
+				deleted++;
 			}
+
 			objFolder.close(true);
 		}
 		else


### PR DESCRIPTION
Instead of marking all messages in folder as read, changes allow one to specify specific messages by messageNumber or uid to mark as read.

Loops on large mailboxes has a major performance hit - several seconds instead of a few milliseconds - so the changes made allow for only looping over messages that need to be marked as read or deleted.