### PR TITLE
Add required attributes for Delete

### DIFF
--- a/imap.cfc
+++ b/imap.cfc
@@ -38,7 +38,8 @@ component output="false" displayname="cfimap"  {
 		DeleteFolder: ['folder'],
 		Close: ['connection'],
 		Open: ['connection','server','username','password'],
-		MoveMail: ['newFolder']
+		MoveMail: ['newFolder'],
+		Delete: ['connection','UID']
 	}
 
 	/**


### PR DESCRIPTION
The Delete option was missing from requiredAttributesPerAction, and therefore threw an error any time that a Delete was attempted.